### PR TITLE
Fix: Add namespace for AGP 8.0 and above compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.vladih.computer_vision.flutter_vision'
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Following issue fixed:
Namespace not specified. Specify a namespace in the module's build file.